### PR TITLE
ESV Passage Search

### DIFF
--- a/config/slash_commands/esv.rb
+++ b/config/slash_commands/esv.rb
@@ -1,0 +1,34 @@
+Houston::Slack.config do
+  slash("esv") do |e|
+    if e.text.blank?
+      # Print usage
+      e.respond! "No search query given. Usage: `/esv <reference>` where reference is a verse reference, e.g. John 3:16 (book abbreviations _are_ supported)."
+    else
+      connection = Faraday.new(url: "http://www.esvapi.org")
+      query = "/v2/rest/passageQuery?#{build_query_with_reference(e.text)}"
+      response = connection.get(query)
+
+      if response.status != 200
+        e.respond! "It looks like ESV is not available at the moment. :sweat:"
+      else
+        e.respond! response.body
+      end
+    end
+  end
+end
+
+def build_query_with_reference(reference)
+  params = esv_params.merge(passage: CGI::escape(reference))
+  params.map { |key, value| "#{key}=#{value}" }.join("&")
+end
+
+def esv_params
+  { key: "IP",
+    "output-format" => "plain-text",
+    "include-footnotes" => false,
+    "include-passage-horizontal-lines" => false,
+    "include-heading-horizontal-lines" => false,
+    "include-headings" => false,
+    "include-subheadings" => false,
+    "line-length" => 0 }
+end

--- a/config/slash_commands/esv.rb
+++ b/config/slash_commands/esv.rb
@@ -11,7 +11,7 @@ Houston::Slack.config do
       if response.status != 200
         e.respond! "It looks like ESV is not available at the moment. :sweat:"
       else
-        e.respond! response.body
+        e.respond! style_passage(response.body)
       end
     end
   end
@@ -31,4 +31,9 @@ def esv_params
     "include-headings" => false,
     "include-subheadings" => false,
     "line-length" => 0 }
+end
+
+def style_passage(text)
+  styled = text.sub(/(.*)$/,"*\\1*")
+  styled
 end

--- a/config/slash_commands/esv.rb
+++ b/config/slash_commands/esv.rb
@@ -2,38 +2,27 @@ Houston::Slack.config do
   slash("esv") do |e|
     if e.text.blank?
       # Print usage
-      e.respond! "No search query given. Usage: `/esv <reference>` where reference is a verse reference, e.g. John 3:16 (book abbreviations _are_ supported)."
+      e.respond! "Hm, looks like you forgot the scripture reference.\nUse `/esv <reference>` to look up a scripture reference.\nExamples:\n* `/esv John 3:16`\n* `/esv Mt 1`\n(Yep, book abbreviations _are_ supported)"
     else
+      esv_params = { key: "IP",
+                     "output-format" => "plain-text",
+                     "include-footnotes" => false,
+                     "include-passage-horizontal-lines" => false,
+                     "include-heading-horizontal-lines" => false,
+                     "include-headings" => false,
+                     "include-subheadings" => false,
+                     "line-length" => 0 }
+
       connection = Faraday.new(url: "http://www.esvapi.org")
-      query = "/v2/rest/passageQuery?#{build_query_with_reference(e.text)}"
+      query = "/v2/rest/passageQuery", esv_params.merge(passage: CGI::escape(e.text))
       response = connection.get(query)
 
       if response.status != 200
         e.respond! "It looks like ESV is not available at the moment. :sweat:"
       else
-        e.respond! style_passage(response.body)
+        styled = response.body.sub(/(.*)$/,"*\\1*")
+        e.respond! styled
       end
     end
   end
-end
-
-def build_query_with_reference(reference)
-  params = esv_params.merge(passage: CGI::escape(reference))
-  params.map { |key, value| "#{key}=#{value}" }.join("&")
-end
-
-def esv_params
-  { key: "IP",
-    "output-format" => "plain-text",
-    "include-footnotes" => false,
-    "include-passage-horizontal-lines" => false,
-    "include-heading-horizontal-lines" => false,
-    "include-headings" => false,
-    "include-subheadings" => false,
-    "line-length" => 0 }
-end
-
-def style_passage(text)
-  styled = text.sub(/(.*)$/,"*\\1*")
-  styled
 end


### PR DESCRIPTION
Uses the ESV api to look up and fetch the Scripture text for the given passage reference.

Usage:
`/esv [reference]` where the reference can be any scripture reference, including abbreviations (since the reference query itself is parsed by ESV).