### PR TITLE
Don't return a next Nanoconf if there isn't one this week

### DIFF
--- a/app/models/nanoconf.rb
+++ b/app/models/nanoconf.rb
@@ -14,6 +14,12 @@ class Nanoconf < ActiveRecord::Base
     upcoming.order(date: :asc).first
   end
 
+  def self.next_for_this_week
+    upcoming.where(arel_table[:date].lt(Date.today.end_of_week))
+            .order(date: :asc)
+            .first
+  end
+
   def past?
     date < Date.today
   end

--- a/config/timers/send_nanoconf_reminders_in_slack.rb
+++ b/config/timers/send_nanoconf_reminders_in_slack.rb
@@ -1,12 +1,12 @@
 Houston.config.every "wednesday at 1:00pm", "announce:upcoming-nanoconf" do
-  nanoconf = Nanoconf.next
+  nanoconf = Nanoconf.next_for_this_week
   next unless nanoconf
   slack_send_message_to "Nanoconf this Friday will be", "it",
     attachments: [slack_nanoconf_attachment(nanoconf)]
 end
 
 Houston.config.every "friday at 12:30pm", "remind:upcoming-nanoconf" do
-  nanoconf = Nanoconf.next
+  nanoconf = Nanoconf.next_for_this_week
   next unless nanoconf
   slack_send_message_to "Just a reminder — Nanoconf starts in 30 minutes!", "it",
     attachments: [slack_nanoconf_attachment(nanoconf)]


### PR DESCRIPTION
Take it or leave it, but my thoughts were to not announce two weeks in advance if there isn't a nanoconf scheduled for the current week. It maybe needs work if you don't like `upcoming` scoped to just the current week, but I think this better matches the behavior you want [here](https://github.com/cph/our-houston/blob/master/config/timers/send_nanoconf_reminders_in_slack.rb#L3).