### PR TITLE
Nanoconf Tweaks

### DIFF
--- a/app/controllers/nanoconfs_controller.rb
+++ b/app/controllers/nanoconfs_controller.rb
@@ -1,5 +1,5 @@
 class NanoconfsController < ApplicationController
-  before_action :set_presentation, only: [:show, :edit, :update]
+  before_action :set_presentation, only: [:show, :edit, :update, :destroy]
   before_action :set_presentations, only: [:index, :new, :edit]
   attr_reader :presentations, :presentation
 
@@ -52,6 +52,15 @@ class NanoconfsController < ApplicationController
       redirect_to presentation
     else
       flash[:error] = "There was a problem"
+    end
+  end
+
+  def destroy
+    authorize! :destroy, @presentation
+    if @presentation.destroy
+      redirect_to nanoconfs_path
+    else
+      flash[:error] = "There was a problem deleting your presentation"
     end
   end
 

--- a/app/views/nanoconfs/show.html.erb
+++ b/app/views/nanoconfs/show.html.erb
@@ -1,4 +1,5 @@
 <div class="nanoconf-info">
+  <div><%= render "back_link" %></div>
   <span class="date"><i class="fa fa-calendar" aria-hidden="true"></i> <%= @presentation.date.strftime("%b %d, %Y") %></span>
   <h2 class="presentation-title">
     <%= @presentation.title %>
@@ -25,5 +26,10 @@
     <% end %>
   </div>
 
-  <%= render "back_link" %>
+  <div>
+    <% if can? :destroy, @presentation %>
+      <% # `link_to` doesn't work without jQuery, so we have to use `button_to` instead %>
+      <%= button_to "Delete", destroy_nanoconf_path(@presentation), method: :delete, class: "btn btn-danger" %>
+    <% end %>
+  </div>
 </div>

--- a/config/abilities.rb
+++ b/config/abilities.rb
@@ -104,7 +104,7 @@ Houston.config do
       can [:update, :destroy], Houston::Feedback::Conversation, user_id: user.id
 
       # Folks can update their own presentations
-      can :update, Nanoconf, presenter_id: user.id
+      can [:update, :destroy], Nanoconf, presenter_id: user.id
 
       # If you're signed in, you can create a Nanoconfs
       can :create, Nanoconf

--- a/config/main.rb
+++ b/config/main.rb
@@ -53,6 +53,12 @@ Houston.add_navigation_renderer :pulls do
   ability { |ability| ability.can?(:read, Github::PullRequest) }
 end
 
+Houston.add_navigation_renderer :nanoconfs do
+  name "Nanoconfs"
+  path { Houston::Engine.routes.url_helpers.nanoconfs_path }
+  ability { |ability| ability.can?(:read, Nanoconf) }
+end
+
 Houston.add_project_column :rails_version do
   name "Rails"
   html { |project| project.props["keyDependency.rails"] }
@@ -189,7 +195,8 @@ Houston.config do
   navigation       :activity_feed,
                    :alerts,
                    :roadmaps,
-                   :pulls
+                   :pulls,
+                   :nanoconfs
   project_features :support_form,
                    :feedback,
                    :ideas,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Houston::Engine.routes.draw do
     get ":id", to: "nanoconfs#show", as: :nanoconf
     get ":id/edit", to: "nanoconfs#edit", as: :edit_nanoconf
     patch ":id", to: "nanoconfs#update", as: :update_nanoconf
+    delete ":id", to: "nanoconfs#destroy", as: :destroy_nanoconf
   end
 
 


### PR DESCRIPTION
This PR does two things:
1. Adds a link to Nanoconfs in the top-level navigation (I kind of wanted to put it in the cog, but it was not immediately obvious how one might go about doing that). And
2. Adds the ability to delete a nanoconf you've created.