### PR TITLE
Prevent leaking connections to the Logeater database

### DIFF
--- a/config/timers/take_measurements.rb
+++ b/config/timers/take_measurements.rb
@@ -24,33 +24,35 @@ end
 # Benchmark.ms { (0..484).each { |i| measure_alerts_closed_on_time! 9.hours.after(Date.today - i) } }
 
 def measure_log_files!(date=Date.today - 2)
-  taken_at = Time.zone.local(date.year, date.month, date.day)
-  range = date.beginning_of_day.utc..date.end_of_day.utc
-  requests = Logeater::Request.where(completed_at: range)
+  Logeater::Request.connection_pool.with_connection do
+    taken_at = Time.zone.local(date.year, date.month, date.day)
+    range = date.beginning_of_day.utc..date.end_of_day.utc
+    requests = Logeater::Request.where(completed_at: range)
 
-  %w{members unite ledger lsb}.each do |project_slug|
-    project = Project.find_by_slug project_slug
-    app_requests = requests.where(app: project_slug)
+    %w{members unite ledger lsb}.each do |project_slug|
+      project = Project.find_by_slug project_slug
+      app_requests = requests.where(app: project_slug)
 
-    # Number of requests that day
-    # Number of requests by HTTP status
-    # Percent of requests that were errors
-    total_requests = 0
-    total_errors = 0
-    app_requests.group(:http_status).pluck(:http_status, "COUNT(*)").each do |status, count|
-      Measurement.take!(name: "daily.requests.#{status}", taken_at: taken_at, subject: project, value: count)
-      total_requests += count
-      total_errors += count if status >= 500
-    end
-    Measurement.take!(name: "daily.requests", taken_at: taken_at, subject: project, value: total_requests)
+      # Number of requests that day
+      # Number of requests by HTTP status
+      # Percent of requests that were errors
+      total_requests = 0
+      total_errors = 0
+      app_requests.group(:http_status).pluck(:http_status, "COUNT(*)").each do |status, count|
+        Measurement.take!(name: "daily.requests.#{status}", taken_at: taken_at, subject: project, value: count)
+        total_requests += count
+        total_errors += count if status >= 500
+      end
+      Measurement.take!(name: "daily.requests", taken_at: taken_at, subject: project, value: total_requests)
 
-    if total_requests > 0
-      Measurement.take!(name: "daily.requests.5xx.percent", taken_at: taken_at, subject: project, value:
-        (total_errors.to_f / total_requests.to_f).round(6))
-      Measurement.take!(name: "daily.requests.duration.mean", taken_at: taken_at, subject: project, value:
-        app_requests.average(:duration).round(4))
-      Measurement.take!(name: "daily.requests.duration.percentile.98", taken_at: taken_at, subject: project, value:
-        app_requests.pluck("percentile_cont(0.98) within group (order by duration asc)")[0])
+      if total_requests > 0
+        Measurement.take!(name: "daily.requests.5xx.percent", taken_at: taken_at, subject: project, value:
+          (total_errors.to_f / total_requests.to_f).round(6))
+        Measurement.take!(name: "daily.requests.duration.mean", taken_at: taken_at, subject: project, value:
+          app_requests.average(:duration).round(4))
+        Measurement.take!(name: "daily.requests.duration.percentile.98", taken_at: taken_at, subject: project, value:
+          app_requests.pluck("percentile_cont(0.98) within group (order by duration asc)")[0])
+      end
     end
   end
 end


### PR DESCRIPTION
Houston has a mechanism whereby connections to _its_ database are managed properly when threaded by the task system; however, the same is not true for connections to the Logeater database. Therefore, we have to do it manually, in this case by wrapping the function in the `with_connection` block. I _think_ this should prevent us leaking connections and needing a restart every 6 days (after we've burned through our 5 pool connections).