### PR TITLE
Don't call it Alertra

### DIFF
--- a/config/events/watchers/slack_if_cron_heartbeat_isnt_running.rb
+++ b/config/events/watchers/slack_if_cron_heartbeat_isnt_running.rb
@@ -1,4 +1,4 @@
-Houston.config.on "watcher:success" => "watcher:notify-if-cron_inactive" do
+Houston.config.on "watcher:success" => "watcher:notify-if-cron-inactive" do
   return unless checkin.project.slug == "ledger"
 
   last_checkin = Time.parse(checkin.info["last_checkin"])

--- a/config/events/watchers/slack_if_something_is_down.rb
+++ b/config/events/watchers/slack_if_something_is_down.rb
@@ -1,0 +1,21 @@
+Houston.config.on "watcher:fail" => "watcher:slack-alerts-on-down" do
+  last_status = Houston::Watcher::Checkin.where.not(id: checkin.id)
+    .order(created_at: :desc)
+    .limit(1)
+    &.status
+  next unless last_status.nil? || last_status == 200
+
+  message = "Heads up, @channel! The check on #{checkin.product.name} failed at #{checkin.created_at} with status code #{checkin.status}"
+  slack_send_message_to message, "ops"
+end
+
+Houston.config.on "watcher:success" => "watcher:slack-alerts-on-back-up" do
+  last_status = Houston::Watcher::Checkin.where.not(id: checkin.id)
+    .order(created_at: :desc)
+    .limit(1)
+    &.status
+  next if last_status.nil? || last_status == 200
+
+  message = "You can relax, @channel. The check on #{checkin.product.name} at #{checkin.created_at} succeeded"
+  slack_send_message_to message, "ops"
+end


### PR DESCRIPTION
I like putting it in the `ops` channel so that there's a searchable record in Slack of up/down alerts, but I _think_ it would be pretty easy to just have Houston DM us instead if you all would prefer... 🤷‍♂ 