### PR TITLE
Show cached PR details alongside associated releases

### DIFF
--- a/app/helpers/gfmarkdown_helper.rb
+++ b/app/helpers/gfmarkdown_helper.rb
@@ -1,0 +1,9 @@
+module GfmarkdownHelper
+  include EmojiHelper
+
+  def gfmdown(text)
+    return "" if text.blank?
+    emojify Kramdown::Document.new(text, input: "GFM").to_html.html_safe
+  end
+
+end

--- a/app/views/houston/releases/releases/_pull_requests.html.erb
+++ b/app/views/houston/releases/releases/_pull_requests.html.erb
@@ -1,0 +1,26 @@
+<%if @release.pull_requests.any? %>
+  <h5 class="release-pull-requests-header">Associated Pull Requests:</h5>
+
+  <div class="release-pull-requests">
+    <% @release.pull_requests.each do |pull_request| %>
+      <div class="release-pull-request">
+        <div class="release-pull-request-title">
+          <%= link_to pull_request.title, pull_request.url, target: "_blank" %>
+        </div>
+        <div class="release-pull-request-author">
+          by <a href="https://github.com/<%= pull_request.username %>" target="_blank">@<%= pull_request.username %></a>
+        </div>
+        <div class="release-pull-request-labels">
+          <% pull_request.labels.each do |label| %>
+            <div class="release-pull-request-label" style="background-color: #<%= label["color"] %>;">
+              <%= label["name"] %>
+            </div>
+          <% end %>
+        </div>
+        <div class="release-pull-request-body">
+          <%= gfmdown(pull_request.body) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/houston/releases/releases/show.html.erb
+++ b/app/views/houston/releases/releases/show.html.erb
@@ -1,0 +1,47 @@
+<% content_for :meta do %>
+  <%= link_to_oembed release_url(@release) %>
+  <%= tag "meta", property: "og:type", content: "website" %>
+  <%= tag "meta", property: "og:site_name", content: "#{@project.slug} / #{@release.environment_name}" %>
+  <%= tag "meta", property: "og:title", content: format_release_subject(@release) %>
+  <%= tag "meta", property: "og:description", content: format_release_description(@release) %>
+  <%= tag "meta", property: "og:url", content: release_url(@release) %>
+  <style>
+    h5.release-pull-requests-header { clear: both; }
+
+    .release-pull-requests .release-pull-request {
+      border-radius: 3px;
+      background-color: #efefef;
+      padding: 1em;
+      margin-bottom: 1em;
+    }
+
+    .release-pull-requests .release-pull-request h3 { font-size: 1.4em; }
+    .release-pull-requests .release-pull-request h4 { font-size: 1.2em; }
+    .release-pull-requests .release-pull-request h5 { font-size: 1em; }
+
+    .release-pull-requests .release-pull-request .release-pull-request-title {
+      font-size: 1.5em;
+      font-weight: bold;
+    }
+
+    .release-pull-requests .release-pull-request .release-pull-request-author {
+      font-size: 0.8em;
+      color: #888;
+    }
+
+    .release-pull-requests .release-pull-request .release-pull-request-labels .release-pull-request-label {
+      display: inline-block;
+      font-size: 0.8em;
+      border-radius: 3px;
+      padding: 0px 6px;
+      color: white;
+      margin-right: 4px;
+    }
+  </style>
+<% end %>
+
+<%= render partial: "projects/header", locals: {project: @project, subtitle: "Release of"} %>
+
+<%= render partial: "houston/releases/releases/changelog" %>
+
+<%= render partial: "houston/releases/releases/pull_requests" %>

--- a/lib/houston/railtie.rb
+++ b/lib/houston/railtie.rb
@@ -1,4 +1,5 @@
 require "user_ext"
+require "release_ext"
 
 module Houston
   class Railtie < ::Rails::Railtie
@@ -8,6 +9,7 @@ module Houston
     config.to_prepare do
       ::User.devise :ldap_authenticatable
       User.extend UserExt::ClassMethods
+      Houston::Releases::Release.send(:include, ReleaseExt)
     end
 
   end

--- a/lib/release_ext.rb
+++ b/lib/release_ext.rb
@@ -1,0 +1,8 @@
+module ReleaseExt
+  extend ActiveSupport::Concern
+
+  def pull_requests
+    Github::PullRequest.joins(:commits).where(Commit.arel_table[:sha].in(commits.pluck(:sha)))
+  end
+
+end


### PR DESCRIPTION
My thought was that we could just add this to `our-houston`, with an eye towards extraction into a PR to `houston-releases` after we've had a chance to try it out and iterate on it a bit.

Example:
![Screen Shot 2019-05-13 at 8 47 23 AM](https://user-images.githubusercontent.com/11465945/57626733-1fa72700-755c-11e9-8161-256c6301eeaf.png)
