### PR TITLE
Checkout (but verify)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GIT
 
 GIT
   remote: https://github.com/houston/houston-core.git
-  revision: fde0f11942852319d58bf1abb34573d89beca819
+  revision: 5531228519ed928b910a79e64a439e8a84dfac94
   branch: master
   specs:
     houston-core (0.9.2)
@@ -328,7 +328,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    css_parser (1.6.0)
+    css_parser (1.7.0)
       addressable
     devise (4.6.1)
       bcrypt (~> 3.0)
@@ -336,9 +336,9 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
-    devise_invitable (1.7.5)
-      actionmailer (>= 4.1.0)
-      devise (>= 4.0.0)
+    devise_invitable (2.0.1)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     docile (1.1.5)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -359,7 +359,7 @@ GEM
     erubi (1.8.0)
     erubis (2.7.0)
     escape (0.0.4)
-    et-orbi (1.1.6)
+    et-orbi (1.2.1)
       tzinfo
     execjs (2.7.0)
     factory_girl (4.9.0)
@@ -373,7 +373,7 @@ GEM
       faraday (~> 0.8)
     faraday-raise-errors (0.3.0)
       faraday
-    ffi (1.10.0)
+    ffi (1.11.1)
     gemoji (2.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -382,7 +382,7 @@ GEM
     graphql-client (0.14.0)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
-    handlebars_assets (0.23.2)
+    handlebars_assets (0.23.4)
       execjs (~> 2.0)
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
@@ -445,7 +445,7 @@ GEM
     net-ldap (0.16.1)
     net-ssh (2.9.4)
     netrc (0.11.0)
-    nio4r (2.3.1)
+    nio4r (2.4.0)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     ntlm-http (0.1.1)
@@ -468,7 +468,7 @@ GEM
       nokogiri
       openxml-package (>= 0.2.0)
     orm_adapter (0.5.0)
-    ox (2.10.0)
+    ox (2.11.0)
     pg (0.21.0)
     pg_search (1.0.6)
       activerecord (>= 3.1)
@@ -532,12 +532,12 @@ GEM
     rr (1.2.1)
     ruby-progressbar (1.10.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     rugged (0.26.7)
     safe_yaml (1.0.4)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -669,4 +669,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.4
+   2.0.2


### PR DESCRIPTION
### Summary
This grabs the fix in `houston-core` that adds a `connection.verify!` when we checkout a connection using `with_connection` when calling `Houston.async`. This _should_ make sure that we're not trying to use a stale connection, which is what's (probably) giving us the `PG::ConnectionBad` errors in Errbit.

I ran `bundle update houston-core --conservative`, but there were still some peripheral gem updates. _Probably_ fine... 🤷‍♂️