### PR TITLE
Disabled Todoist integration

### DIFF
--- a/config/events/alerts/sync_alerts_to_todoist.rb
+++ b/config/events/alerts/sync_alerts_to_todoist.rb
@@ -1,8 +1,8 @@
-Houston.config do
-  action "alert:sync-to-todoist", %w{alert} do
-    sync_alert_to_todoist alert
-  end
-
-  on "alert:create" => "alert:sync-to-todoist"
-  on "alert:update" => "alert:sync-to-todoist"
-end
+# Houston.config do
+#   action "alert:sync-to-todoist", %w{alert} do
+#     sync_alert_to_todoist alert
+#   end
+#
+#   on "alert:create" => "alert:sync-to-todoist"
+#   on "alert:update" => "alert:sync-to-todoist"
+# end

--- a/config/integrations/todoist.rb
+++ b/config/integrations/todoist.rb
@@ -1,4 +1,4 @@
-Houston.config.oauth :todoist do
-  client_id ENV["HOUSTON_TODOIST_CLIENT_ID"]
-  client_secret ENV["HOUSTON_TODOIST_CLIENT_SECRET"]
-end
+# Houston.config.oauth :todoist do
+#   client_id ENV["HOUSTON_TODOIST_CLIENT_ID"]
+#   client_secret ENV["HOUSTON_TODOIST_CLIENT_SECRET"]
+# end

--- a/config/main.rb
+++ b/config/main.rb
@@ -247,7 +247,7 @@ Houston.config do
   use :feedback
   # use :brakeman
   # use :sprints
-  use :todolists
+  # use :todolists
   use :roadmaps
 
   use :releases do

--- a/config/timers/sync_alerts_to_todoist.rb
+++ b/config/timers/sync_alerts_to_todoist.rb
@@ -1,3 +1,3 @@
-Houston.config.every "10m", "sync:alerts-and-todoist" do
-  sync_open_alerts_to_todoist
-end
+# Houston.config.every "10m", "sync:alerts-and-todoist" do
+#   sync_open_alerts_to_todoist
+# end

--- a/config/timers/sync_todoist.rb
+++ b/config/timers/sync_todoist.rb
@@ -1,3 +1,3 @@
-Houston.config.every "1h", "sync:todoist" do
-  Todoist.sync!
-end
+# Houston.config.every "1h", "sync:todoist" do
+#   Todoist.sync!
+# end


### PR DESCRIPTION
 Until `houston-todolists` module can be updated for new API (Todoist forked its API into v8 of the "sync" API and v1 of their "REST" api)