### PR TITLE
Gracefully Fail at GraphQL

### DIFF
--- a/config/integrations/github_graphql.rb
+++ b/config/integrations/github_graphql.rb
@@ -34,7 +34,7 @@ module GitHubQL
 
       query_string = repos.sort.map { |r| "repo:#{r}" }.join(" ")
       result = client.query(VulnerabilityAlertQuery, variables: { "queryString" => query_string  })
-      result.data.search.edges.each_with_object([]) do |edge, alerts|
+      (result.data&.search&.edges || []).each_with_object([]) do |edge, alerts|
         repo = edge.node
         repo.vulnerability_alerts.nodes.each do |alert|
           next if alert.dismissed_at


### PR DESCRIPTION
### Summary
The GraphQL client does some fancy wrapping of a hash, which means that if the data isn't there in the request result (likely due to a hiccup on GH's end?), we'll run into a `nil`. Since this is a periodic check, there's no harm in gracefully handling not getting the data we expected back for one query.