### PR TITLE
Change reminder times

### DIFF
--- a/config/timers/send_nanoconf_reminders_in_slack.rb
+++ b/config/timers/send_nanoconf_reminders_in_slack.rb
@@ -1,11 +1,11 @@
-Houston.config.every "wednesday at 1:00pm", "announce:upcoming-nanoconf" do
+Houston.config.every "wednesday at 2:00pm", "announce:upcoming-nanoconf" do
   nanoconf = Nanoconf.next_for_this_week
   next unless nanoconf
   slack_send_message_to "Nanoconf this Friday will be", "it",
     attachments: [slack_nanoconf_attachment(nanoconf)]
 end
 
-Houston.config.every "friday at 12:30pm", "remind:upcoming-nanoconf" do
+Houston.config.every "friday at 1:30pm", "remind:upcoming-nanoconf" do
   nanoconf = Nanoconf.next_for_this_week
   next unless nanoconf
   slack_send_message_to "Just a reminder — Nanoconf starts in 30 minutes!", "it",

--- a/config/timers/slack_reminders_to_enter_time.rb
+++ b/config/timers/slack_reminders_to_enter_time.rb
@@ -1,6 +1,6 @@
 Houston.config do
 
-  every "weekday at 12:00pm", "remind:startime" do
+  every "weekday at 3:00pm", "remind:startime" do
     today = Date.today
     first_of_month = today.beginning_of_month
     yesterday = today - 1


### PR DESCRIPTION
### Summary
Changes time entry from 12pm ➡️ 3pm
Changes nanoconf from 1pm Friday ➡️ 2pm Friday (since most 1-on-1s are at 1pm on Friday)