### PR TITLE
Deploy Heroku apps via Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem "redis", "< 4.0"
 # for talking to GitHub
 gem "graphql-client"
 
+# for talking to Heroku
+gem "platform-api"
+
 group :development do
   gem "letter_opener"
   gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,7 @@ GEM
     escape (0.0.4)
     et-orbi (1.2.1)
       tzinfo
+    excon (0.67.0)
     execjs (2.7.0)
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
@@ -387,6 +388,11 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (0.3.8)
+    heroics (0.0.25)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     highline (1.6.21)
     houston-vestal_versions (2.0.1)
       activerecord (>= 3, < 6)
@@ -435,6 +441,7 @@ GEM
       ruby-progressbar
     minitest-reporters-turn_reporter (0.1.2)
       minitest-reporters
+    moneta (1.0.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -474,6 +481,9 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
     pluck_map (0.2.1)
     premailer (1.10.4)
       addressable
@@ -548,9 +558,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     shoulda-context (1.2.2)
     simplecov (0.9.2)
       docile (~> 1.1.0)
@@ -651,6 +661,7 @@ DEPENDENCIES
   minitest
   minitest-reporters
   minitest-reporters-turn_reporter
+  platform-api
   pry
   puma
   redis (< 4.0)

--- a/app/interactors/deployers/heroku.rb
+++ b/app/interactors/deployers/heroku.rb
@@ -1,0 +1,85 @@
+require "platform-api"
+
+module Deployers
+  class Heroku
+    attr_reader :project, :environment_name
+
+    class Logger
+      attr_reader :streams
+
+      def initialize(*streams)
+        @streams = streams
+      end
+
+      def output(str)
+        streams.each { |stream| stream.puts str }
+      end
+      alias info output
+      alias debug output
+    end
+
+    def initialize(project, environment_name)
+      @project = project
+      @environment_name = environment_name
+    end
+
+    def last_deploy_commit
+      releases = heroku.release.list(app_name).to_a
+      id = releases.last.fetch("slug").fetch("id")
+      slug = heroku.slug.info(app_name, id)
+      slug.fetch("commit")
+    end
+
+    def deploy(deploy, options={})
+      begin
+        project.repo.refresh!
+
+        rugged_repo = project.repo.send(:connection)
+        branch_ref = rugged_repo.refs.find { |ref| ref.target_id == deploy.sha }
+        heroku_remote = rugged_repo.remotes.create_anonymous(heroku_git_url)
+
+        # The + in the refspec means --force
+        result = heroku_remote.push(
+          [ "+#{branch_ref.canonical_name}:refs/heads/master" ],
+          progress: ->(txt) { deploy.output_stream << txt },
+          credentials: Houston::Adapters::VersionControl::GitAdapter.credentials)
+
+        successful = result.empty?
+        record_outcome_of! deploy, successful: successful
+      rescue Exception
+        record_outcome_of! deploy, successful: false
+        raise
+      end
+
+      deploy.successful?
+    end
+
+  private
+
+    def app_name
+      app_name = "#{project.slug}-#{environment_name}".gsub("_", "-")
+      HEROKU_ALIASES.fetch(app_name, app_name)
+    end
+
+    def heroku_git_url
+      "git@heroku.com:#{app_name}.git"
+    end
+
+    def heroku
+      @heroku ||= PlatformAPI.connect_oauth ENV["HOUSTON_PLATFORM_API_OAUTH_TOKEN"]
+    end
+
+    def record_outcome_of!(deploy, successful: true)
+      Houston.try({ max_tries: 5, ignore: true }, exceptions_wrapping(PG::ConnectionBad)) do
+        deploy.update! successful: successful, completed_at: Time.now
+      end
+    end
+
+    HEROKU_ALIASES = {
+      "members-production" => "members-production-8081",
+      "members-staging2" => "members-staging",
+      "mss-staging" => "music-subscription-staging"
+    }.freeze
+
+  end
+end

--- a/config/conversations/commands/deploy.rb
+++ b/config/conversations/commands/deploy.rb
@@ -64,7 +64,12 @@ module Houston
       YESORNO = ["(?<affirmative>yes|ok|sure|yeah|ya)", "(?<negative>no)"].freeze
       ACKNOWLEDGEMENT = ["Alright, thanks.", "OK", "got it", "ok", "ok"].freeze
       DEPLOYABLE_REPOS = %w{
+        cph/members
         cph/ledger
+        cph/unite
+        cph/confb
+        cph/dr
+        cph/mss
       }.freeze
 
 
@@ -212,7 +217,7 @@ module Houston
         # we're just deploying members, unite, and ledger to Staging for now,
         # so we can assume that the strategy is Engineyard
         environment_name = project == "lsb" ? "staging2" : "staging"
-        @environment = Deployers::Engineyard.new(project, environment_name)
+        @environment = Deployers::Heroku.new(project, environment_name)
         check_if_another_pull_request_is_on_staging
       rescue Exception
         report! $!


### PR DESCRIPTION
### Summary
Now that all the 360 apps are on Heroku, it seemed about time to spike on bringing this back to Slack. It seemed to work for me when running locally, but there still may be some kinks to work out when using it on production Houston (and of course `ep deploy staging` will still work). Let me know what you think!

NB: LSB is still unsupported, since it will require this, _plus_ running `ember deploy`, which is another spike for another day. 😅 