### PR TITLE
Bumped octokit to handle dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "slacks", ">= 0.5.0.pre", github: "houston/slacks", branch: "master"
 gem "houston-alerts", github: "houston/houston-alerts", branch: "master"
 # gem "houston-brakeman", github: "houston/houston-brakeman", branch: "master"
 gem "houston-ci", github: "houston/houston-ci", branch: "master"                      # Jenkins
-gem "houston-commits", github: "houston/houston-commits", branch: "master"            # GitHub
+gem "houston-commits", github: "houston/houston-commits", branch: "upgrade-octokit"            # GitHub
 gem "houston-exceptions", github: "houston/houston-exceptions", branch: "master"      # Errbit
 gem "houston-feedback", github: "houston/houston-feedback", branch: "master"
 gem "houston-releases", github: "houston/houston-releases", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,12 +65,12 @@ GIT
 
 GIT
   remote: https://github.com/houston/houston-commits.git
-  revision: 33592b9ad980b596459a392b49bc6dab1914d8fe
-  branch: master
+  revision: 1b5800e3e339faa917a47bdcde3a40f0ec0803bd
+  branch: upgrade-octokit
   specs:
     houston-commits (0.0.1)
       houston-core (>= 0.8.0)
-      octokit (~> 4.6.2)
+      octokit (>= 4.9.0)
       rugged (~> 0.26.0)
 
 GIT
@@ -464,7 +464,7 @@ GEM
       rack (>= 1.2, < 3)
     octicons (8.2.0)
       nokogiri (>= 1.6.3.1)
-    octokit (4.6.2)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.7.6)
     openxml-package (0.3.3)


### PR DESCRIPTION
The test added in the PR that fixed this in Octokit 4.9.0 explicitly used a bot username as an example of the problem. 😅